### PR TITLE
Register Netlify contact form (redeploy with detection on)

### DIFF
--- a/src/components/ContactForm.astro
+++ b/src/components/ContactForm.astro
@@ -10,7 +10,7 @@
   method="POST"
   data-netlify="true"
   netlify-honeypot="bot-field"
-  action="/contact/success"
+  action="/contact/success/"
   class="form"
 >
   <input type="hidden" name="form-name" value="contact" />


### PR DESCRIPTION
Form detection was enabled *after* the previous deploys, so the contact form was never scanned/registered — POST submissions 404'd. This redeploys with detection on so Netlify registers the form. Also points the form action at the trailing-slash success URL to avoid a 301 hop.