### PR TITLE
GEO: structured data + llms.txt; Cloudflare Web Analytics

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -24,7 +24,7 @@
     Referrer-Policy = "strict-origin-when-cross-origin"
     Strict-Transport-Security = "max-age=63072000; includeSubDomains; preload"
     Permissions-Policy = "geolocation=(), camera=(), microphone=(), payment=(), usb=(), interest-cohort=()"
-    Content-Security-Policy = "default-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; frame-src https://www.youtube-nocookie.com; img-src 'self' data:; style-src 'self' 'unsafe-inline'; font-src 'self'; script-src 'self'; connect-src 'self'; manifest-src 'self'"
+    Content-Security-Policy = "default-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; frame-src https://www.youtube-nocookie.com; img-src 'self' data:; style-src 'self' 'unsafe-inline'; font-src 'self'; script-src 'self' https://static.cloudflareinsights.com; connect-src 'self' https://cloudflareinsights.com; manifest-src 'self'"
 
 # Long-cache hashed build assets.
 [[headers]]

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,37 @@
+# yay.dev — Doron Tsur
+
+> Doron Tsur is a Platform & Distributed Systems Architect with 15 years of
+> experience building the infrastructure other teams rely on: large scale
+> search, data pipelines, event driven systems, and the infrastructure as code
+> underneath them. He runs an independent consulting practice (yay.dev) and is
+> a partner at Codo.
+
+## About
+
+- Role: Platform & Distributed Systems Architect
+- Practice: yay.dev (independent consulting), Founder & Principal Consultant
+- Partner & Senior System Architect at Codo
+- Based in Israel. Works end to end: architecture, the hard performance core,
+  and the operations to run it. Test driven by default.
+- Core stack: TypeScript, Rust, Go, Python, AWS, Terraform, Kubernetes,
+  OpenSearch / Elasticsearch, ClickHouse, Apache Kafka, PostgreSQL.
+- Focus areas: large scale search, data pipelines and change data capture,
+  event driven and distributed systems, platform/infrastructure engineering.
+
+## Pages
+
+- [Home](https://yay.dev/): overview, services, and stack.
+- [Résumé](https://yay.dev/resume): full experience (Codo, yay.dev practice
+  with engagements, HoneyBook, Cloudinary, Tikal, Bit, Wix), skills, education.
+- [Talks](https://yay.dev/talks): conference talks — "TestContainers: Real
+  Integration Tests Without the Pain" (NodeTLV 2025) and "Are we Deno yet?"
+  (NodeTLV 2021).
+- [Blog](https://yay.dev/blog): notes on platform engineering, distributed
+  systems, search and data infrastructure.
+- [Contact](https://yay.dev/contact): contact form and links.
+
+## Contact
+
+- LinkedIn: https://www.linkedin.com/in/doron-tsur
+- GitHub: https://github.com/qballer
+- Contact form: https://yay.dev/contact

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,27 @@
+# All crawlers welcome, including AI/LLM crawlers (GEO).
 User-agent: *
+Allow: /
+
+# Explicitly welcome major AI crawlers.
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Google-Extended
 Allow: /
 
 Sitemap: https://yay.dev/sitemap-index.xml

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -13,12 +13,69 @@ interface Props {
   noindex?: boolean;
 }
 const { title, description, image, type, noindex } = Astro.props;
+
+// Structured data — helps search engines and LLMs resolve the entity (who
+// Doron is, what he knows, where else he is online) and cite it confidently.
+const structuredData = {
+  '@context': 'https://schema.org',
+  '@graph': [
+    {
+      '@type': 'WebSite',
+      '@id': `${SITE.url}/#website`,
+      url: `${SITE.url}/`,
+      name: SITE.name,
+      description: SITE.description,
+      inLanguage: 'en',
+      publisher: { '@id': `${SITE.url}/#person` },
+    },
+    {
+      '@type': 'Person',
+      '@id': `${SITE.url}/#person`,
+      name: SITE.author,
+      url: `${SITE.url}/`,
+      jobTitle: SITE.role,
+      description:
+        'Platform and distributed systems engineer. Independent consulting practice (yay.dev) and partner at Codo.',
+      knowsAbout: [
+        'Platform engineering',
+        'Distributed systems',
+        'Large scale search',
+        'OpenSearch',
+        'Elasticsearch',
+        'ClickHouse',
+        'Data pipelines',
+        'Change data capture',
+        'Apache Kafka',
+        'AWS',
+        'Terraform',
+        'Kubernetes',
+        'TypeScript',
+        'Rust',
+        'Go',
+        'Python',
+        'PostgreSQL',
+      ],
+      alumniOf: {
+        '@type': 'CollegeOrUniversity',
+        name: 'The Academic College of Tel Aviv-Yaffo',
+      },
+      sameAs: [
+        'https://github.com/qballer',
+        'https://www.linkedin.com/in/doron-tsur',
+      ],
+    },
+  ],
+};
 ---
 
 <!doctype html>
 <html lang={SITE.locale}>
   <head>
     <Seo {title} {description} {image} {type} {noindex} />
+    <script
+      type="application/ld+json"
+      set:html={JSON.stringify(structuredData)}
+    />
   </head>
   <body>
     <a href="#main" class="skip-link">Skip to content</a>
@@ -27,5 +84,11 @@ const { title, description, image, type, noindex } = Astro.props;
       <slot />
     </main>
     <Footer />
+    <!-- Cloudflare Web Analytics (cookieless) -->
+    <script
+      is:inline
+      defer
+      src="https://static.cloudflareinsights.com/beacon.min.js"
+      data-cf-beacon='{"token": "26c7282bdd4d46a2934c8326d83c64c1"}'></script>
   </body>
 </html>


### PR DESCRIPTION
Makes the site more discoverable/citable by search engines and LLMs, and adds privacy-friendly analytics.

## GEO
- **JSON-LD** (schema.org `WebSite` + `Person`): jobTitle, knowsAbout (stack), alumniOf, sameAs (GitHub/LinkedIn) — entity identity for search + LLM citation.
- **/llms.txt**: curated markdown summary + key links for AI agents.
- **robots.txt**: explicit welcome for GPTBot, OAI-SearchBot, ClaudeBot, PerplexityBot, Google-Extended.

## Analytics
- **Cloudflare Web Analytics** beacon (cookieless, no consent banner needed).
- CSP narrowed-addition: `static.cloudflareinsights.com` (script) + `cloudflareinsights.com` (connect).

Lighthouse on the current live site: Perf 98 / A11y 100 / Best-practices 92 / SEO 100.