### PR TITLE
Cache-bust favicon so the brand icon shows

### DIFF
--- a/src/components/Seo.astro
+++ b/src/components/Seo.astro
@@ -55,8 +55,8 @@ const imageUrl = new URL(image, SITE.url).href;
 />
 
 <!-- Icons -->
-<link rel="icon" href="/favicon.svg" type="image/svg+xml" />
-<link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+<link rel="icon" href="/favicon.svg?v=2" type="image/svg+xml" />
+<link rel="apple-touch-icon" href="/apple-touch-icon.png?v=2" />
 
 <!-- Search engine verification slots (fill when ready) -->
 <!-- <meta name="google-site-verification" content="" /> -->


### PR DESCRIPTION
The live favicon is already the brand icon, but browsers cached the old green one from the early deploys (favicons cache aggressively). Adds ?v=2 to the favicon/apple-touch-icon URLs to force a re-fetch for all visitors.