### PR TITLE
Rename Blog -> Notes

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -8,6 +8,17 @@
 [build.environment]
   NODE_VERSION = "24"
 
+# Blog was renamed to Notes; keep old URLs working.
+[[redirects]]
+  from = "/blog"
+  to = "/notes"
+  status = 301
+
+[[redirects]]
+  from = "/blog/*"
+  to = "/notes/:splat"
+  status = 301
+
 # Astro emits a 404.html; serve it on unmatched routes.
 [[redirects]]
   from = "/*"

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -26,7 +26,7 @@
 - [Talks](https://yay.dev/talks): conference talks — "TestContainers: Real
   Integration Tests Without the Pain" (NodeTLV 2025) and "Are we Deno yet?"
   (NodeTLV 2021).
-- [Blog](https://yay.dev/blog): notes on platform engineering, distributed
+- [Notes](https://yay.dev/notes): writing on platform engineering, distributed
   systems, search and data infrastructure.
 - [Contact](https://yay.dev/contact): contact form and links.
 

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -18,7 +18,7 @@ export const SITE = {
 export const NAV: { label: string; href: string }[] = [
   { label: 'Résumé', href: '/resume' },
   { label: 'Talks', href: '/talks' },
-  { label: 'Blog', href: '/blog' },
+  { label: 'Notes', href: '/notes' },
   { label: 'Contact', href: '/contact' },
 ];
 

--- a/src/pages/notes/[...slug].astro
+++ b/src/pages/notes/[...slug].astro
@@ -22,7 +22,7 @@ const fmt = (d: Date) =>
   type="article"
 >
   <article class="wrap prose post">
-    <p class="eyebrow"><a href="/blog">← all notes</a></p>
+    <p class="eyebrow"><a href="/notes">← all notes</a></p>
     <h1>{post.data.title}</h1>
     <p class="meta">
       <time datetime={post.data.pubDate.toISOString()}>{fmt(post.data.pubDate)}</time>

--- a/src/pages/notes/index.astro
+++ b/src/pages/notes/index.astro
@@ -11,11 +11,11 @@ const fmt = (d: Date) =>
 ---
 
 <BaseLayout
-  title="Blog"
+  title="Notes"
   description="Notes on platform engineering, distributed systems, search and data infrastructure."
 >
   <div class="wrap prose">
-    <p class="eyebrow">// blog</p>
+    <p class="eyebrow">// notes</p>
     <h1>Notes</h1>
     <p class="lede">
       Writing on platform engineering, distributed systems, search and data
@@ -37,7 +37,7 @@ const fmt = (d: Date) =>
         <ul class="post-list">
           {posts.map((post) => (
             <li>
-              <a href={`/blog/${post.id}`}>
+              <a href={`/notes/${post.id}`}>
                 <time datetime={post.data.pubDate.toISOString()}>
                   {fmt(post.data.pubDate)}
                 </time>

--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -14,7 +14,7 @@ export async function GET(context) {
         title: post.data.title,
         description: post.data.description,
         pubDate: post.data.pubDate,
-        link: `/blog/${post.id}/`,
+        link: `/notes/${post.id}/`,
       })),
   });
 }


### PR DESCRIPTION
Per our content discussion, frames the section as 'Notes' consistently: route /blog -> /notes, nav + eyebrow updated, RSS/llms.txt links updated, with 301 redirects from /blog so nothing breaks.