### PR TITLE
Add agent-discovery files (security.txt, humans.txt, llms-full.txt)

### DIFF
--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,0 +1,5 @@
+# Security contact for yay.dev
+Contact: https://yay.dev/contact
+Preferred-Languages: en, he
+Canonical: https://yay.dev/.well-known/security.txt
+Expires: 2027-06-13T00:00:00.000Z

--- a/public/humans.txt
+++ b/public/humans.txt
@@ -1,0 +1,11 @@
+/* TEAM */
+Doron Tsur — Platform & Distributed Systems Architect
+Site: https://yay.dev
+GitHub: https://github.com/qballer
+LinkedIn: https://www.linkedin.com/in/doron-tsur
+WhatsApp: https://wa.me/972546342237
+
+/* SITE */
+Built with: Astro (static), hosted on Netlify
+Standards: HTML5, semantic markup, JSON-LD structured data
+Languages: English, Hebrew

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -1,0 +1,58 @@
+# yay.dev — Doron Tsur (full)
+
+> Doron Tsur is a Platform & Distributed Systems Architect with 15 years of
+> experience building the infrastructure other teams rely on: large scale
+> search, data pipelines, event driven systems, and the infrastructure as code
+> underneath them. He runs an independent consulting practice (yay.dev) and is
+> a partner at Codo. Based in Israel.
+
+## What he does
+
+Works end to end: architecture, the hard performance core, and the operations
+to run it. Test driven by default. Most comfortable taking an ambiguous
+platform problem and turning it into something other engineers can build on.
+
+Service areas:
+- Platform & infrastructure engineering (AWS, ECS, Kubernetes, Terraform/IaC,
+  CI/CD, observability)
+- Distributed systems and large scale search (OpenSearch / Elasticsearch,
+  ClickHouse, event driven systems, performance and cost tuning)
+- Data pipelines and change data capture (high throughput ingestion, CDC
+  tooling, load testing and reliability)
+- AI engineering (LLM features into platforms, retrieval and search over data)
+
+Core stack: TypeScript, Rust, Go, Python, AWS, Terraform, Kubernetes,
+OpenSearch / Elasticsearch, ClickHouse, Apache Kafka, PostgreSQL.
+
+## Experience (selected)
+
+- Codo — Senior System Architect & Partner (2026–present): architected and
+  built a large scale video ingestion, transcription and search platform on
+  AWS and OpenSearch; TypeScript/Node.js microservices with a Rust performance
+  core and full Terraform IaC.
+- yay.dev — Founder & Principal Consultant (2024–present): independent
+  platform and data engineering practice; designed a change data capture (CDC)
+  library that generates dynamic SQL from table structure.
+- Earlier: HoneyBook (Senior Staff Engineer), Cloudinary, Tikal, Bit
+  (Cocycles), Wix.
+
+## Talks
+
+- "TestContainers: Real Integration Tests Without the Pain" — NodeTLV 2025.
+- "Are we Deno yet?" — NodeTLV 2021 (English and Hebrew).
+
+## Pages
+
+- Home: https://yay.dev/
+- Résumé: https://yay.dev/resume
+- Talks: https://yay.dev/talks
+- Notes (blog): https://yay.dev/notes
+- Contact: https://yay.dev/contact
+
+## Contact
+
+Prefer a human-initiated reach-out. To get in touch with Doron:
+- Contact form: https://yay.dev/contact
+- LinkedIn: https://www.linkedin.com/in/doron-tsur
+- GitHub: https://github.com/qballer
+- WhatsApp: https://wa.me/972546342237

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -32,6 +32,9 @@
 
 ## Contact
 
+- Contact form: https://yay.dev/contact
 - LinkedIn: https://www.linkedin.com/in/doron-tsur
 - GitHub: https://github.com/qballer
-- Contact form: https://yay.dev/contact
+- WhatsApp: https://wa.me/972546342237
+
+Full version: https://yay.dev/llms-full.txt


### PR DESCRIPTION
The applicable subset of AgentGrade's checklist for a personal site: adds /.well-known/security.txt, /humans.txt, /llms-full.txt, and a WhatsApp line in llms.txt. Deliberately NOT adding MCP/payment/OpenAPI surfaces (N/A for a portfolio) and keeping the contact form human-oriented.